### PR TITLE
Clean up getAvatarUrl method by removing comment

### DIFF
--- a/src/main/java/com/rabbitinfosystems/ticketingsystem/service/AvatarService.java
+++ b/src/main/java/com/rabbitinfosystems/ticketingsystem/service/AvatarService.java
@@ -30,7 +30,6 @@ public class AvatarService {
     }
 
     public String getAvatarUrl(String key) {
-        //"http://<your-vps-ip>:9000/" + BUCKET + "/" + key;
         return s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(key)).toString();
     }
 }


### PR DESCRIPTION
Removed commented placeholder URL from getAvatarUrl method.